### PR TITLE
Add tests for persisting food to DB

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -22,7 +22,10 @@ dependencies {
 	implementation("org.springframework.boot:spring-boot-starter-data-rest")
 	implementation("org.jetbrains.kotlin:kotlin-reflect")
 	implementation("org.jetbrains.kotlin:kotlin-stdlib-jdk8")
+	testImplementation("org.junit.jupiter:junit-jupiter-api:5.8.1")
+	testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:5.8.1")
 	testImplementation("org.springframework.boot:spring-boot-starter-test")
+	testImplementation("io.zonky.test:embedded-database-spring-test:2.1.1")
 }
 
 tasks.withType<KotlinCompile> {

--- a/src/main/kotlin/com/vacuumlabs/learning/service/FoodService.kt
+++ b/src/main/kotlin/com/vacuumlabs/learning/service/FoodService.kt
@@ -1,6 +1,7 @@
 package com.vacuumlabs.learning.service
 
 import com.vacuumlabs.learning.entity.food.Food
+import com.vacuumlabs.learning.entity.ingredient.Ingredient
 import com.vacuumlabs.learning.repository.FoodRepository
 import com.vacuumlabs.learning.service.exception.InvalidDataException
 import org.springframework.beans.factory.annotation.Autowired
@@ -23,8 +24,13 @@ class FoodService @Autowired constructor(
     fun throwIfFoodNotValid(food: Food) {
         if(food.name.isBlank()) { throw InvalidDataException("Food name must consist of at least one character!") }
         if(food.ingredients.isEmpty()) { throw InvalidDataException("Food needs to have at least one ingredient!") }
+        if(hasDuplicateIngredientByName(food.ingredients)) { throw InvalidDataException("There are two ingredients with the same name, ingredients must have unique names!") }
 
         food.ingredients.forEachIndexed { index, ingredient ->  ingredientService.throwIfIngredientNotValid(ingredient, index) }
+    }
+
+    fun hasDuplicateIngredientByName(ingredients : List<Ingredient>) : Boolean {
+        return ingredients.size != ingredients.distinctBy { it.name }.size
     }
 
     @Transactional(rollbackFor = [Exception::class])

--- a/src/main/kotlin/com/vacuumlabs/learning/startup/runners/DatabasePopulationRunner.kt
+++ b/src/main/kotlin/com/vacuumlabs/learning/startup/runners/DatabasePopulationRunner.kt
@@ -8,9 +8,11 @@ import com.vacuumlabs.learning.repository.FoodRepository
 import com.vacuumlabs.learning.repository.FoodTagRepository
 import com.vacuumlabs.learning.startup.OrderedCommandLineRunner
 import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
 @Component
+@Profile("!test")
 class DatabasePopulationRunner @Autowired constructor(
     val foodRepository : FoodRepository,
     val foodTagRepository: FoodTagRepository

--- a/src/main/kotlin/com/vacuumlabs/learning/startup/runners/FinishRunner.kt
+++ b/src/main/kotlin/com/vacuumlabs/learning/startup/runners/FinishRunner.kt
@@ -1,10 +1,12 @@
 package com.vacuumlabs.learning.startup.runners
 
 import com.vacuumlabs.learning.startup.OrderedCommandLineRunner
+import org.springframework.context.annotation.Profile
 import org.springframework.stereotype.Component
 
 
 @Component
+@Profile("!test")
 class FinishRunner : OrderedCommandLineRunner() {
 
     override fun run(vararg args: String?) {

--- a/src/test/kotlin/com/vacuumlabs/learning/FoodServiceSaveTests.kt
+++ b/src/test/kotlin/com/vacuumlabs/learning/FoodServiceSaveTests.kt
@@ -1,0 +1,121 @@
+package com.vacuumlabs.learning
+
+import com.vacuumlabs.learning.entity.food.Food
+import com.vacuumlabs.learning.entity.ingredient.Ingredient
+import com.vacuumlabs.learning.entity.ingredient.IngredientUnitType
+import com.vacuumlabs.learning.entity.tag.FoodTag
+import com.vacuumlabs.learning.repository.FoodTagRepository
+import com.vacuumlabs.learning.service.FoodService
+import com.vacuumlabs.learning.service.exception.InvalidDataException
+import io.zonky.test.db.AutoConfigureEmbeddedDatabase
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.assertThrows
+import org.springframework.beans.factory.annotation.Autowired
+import org.springframework.boot.test.context.SpringBootTest
+import org.springframework.test.context.ActiveProfiles
+
+@ActiveProfiles("test")
+@SpringBootTest
+@AutoConfigureEmbeddedDatabase(refresh = AutoConfigureEmbeddedDatabase.RefreshMode.BEFORE_EACH_TEST_METHOD)
+class FoodServiceSaveTests @Autowired constructor(
+    private val foodService: FoodService,
+    private val foodTagRepository: FoodTagRepository
+) {
+
+    @Test()
+    fun givenEmptyFood_thenThrowException() {
+        assertThrows<InvalidDataException> {
+            foodService.saveFood(Food())
+        }
+    }
+
+    @Test()
+    fun givenFoodWithNoIngredients_thenThrowException() {
+        val food = Food("Test food", mutableListOf(), mutableSetOf())
+
+        assertThrows<InvalidDataException> {
+            foodService.saveFood(food)
+        }
+    }
+
+    @Test()
+    fun givenFoodWithNoName_thenThrowException() {
+        val food = Food("", mutableListOf(Ingredient("Test", IngredientUnitType.PCS, 1, Food())), mutableSetOf())
+
+        assertThrows<InvalidDataException> {
+            foodService.saveFood(food)
+        }
+    }
+
+    @Test()
+    fun givenFoodWithIngredientWithNoName_thenThrowException() {
+        val food = Food("Test food", mutableListOf(Ingredient("", IngredientUnitType.PCS, 1, Food())), mutableSetOf())
+
+        assertThrows<InvalidDataException> {
+            foodService.saveFood(food)
+        }
+    }
+
+    @Test()
+    fun givenFoodWithNonPositiveAmount_thenThrowException() {
+        val food = Food("Test food", mutableListOf(Ingredient("Test", IngredientUnitType.PCS, 0, Food())), mutableSetOf())
+
+        assertThrows<InvalidDataException> {
+            foodService.saveFood(food)
+        }
+    }
+
+    @Test()
+    fun givenFoodWithTwoSameIngredients_thenThrowException() {
+        val food = Food("Test food",
+            mutableListOf(Ingredient("Test", IngredientUnitType.PCS, 1, Food()), Ingredient("Test", IngredientUnitType.PCS, 1, Food())),
+            mutableSetOf()
+        )
+
+        assertThrows<InvalidDataException> {
+            foodService.saveFood(food)
+        }
+    }
+
+    @Test()
+    fun givenFoodWithExistingTag_thenUseTagFromDbWhenSavingFood() {
+
+        val tag = FoodTag("testTag")
+        val savedTag = foodTagRepository.save(tag)
+
+        val food = Food("Test food",
+            mutableListOf(Ingredient("Test", IngredientUnitType.PCS, 1, Food())),
+            mutableSetOf(FoodTag("testTag"))
+        )
+
+        val savedFood = foodService.saveFood(food)
+
+        assert(savedTag.id == savedFood.tags.first().id)
+    }
+
+    @Test()
+    fun givenFoodWithTwoSameTags_thenOnlyOneTagSavedToDb() {
+        val food = Food("Test food",
+            mutableListOf(Ingredient("Test", IngredientUnitType.PCS, 1, Food())),
+            mutableSetOf(FoodTag("testTag"), FoodTag("testTag"))
+        )
+
+        val savedFood = foodService.saveFood(food)
+
+        assert(savedFood.tags.size == 1)
+        assert(savedFood.tags.first().name == "testTag")
+    }
+
+    @Test()
+    fun givenValidFood_thenIsSavedToDb() {
+        val food = Food("Test food",
+            mutableListOf(Ingredient("Test", IngredientUnitType.PCS, 1, Food()), Ingredient("Test 2", IngredientUnitType.G, 200, Food())),
+            mutableSetOf(FoodTag("testTag"), FoodTag("testTag 2"))
+        )
+
+        val savedFood = foodService.saveFood(food)
+        val allFood = foodService.getAll()
+
+        assert(savedFood.id == allFood.first().id)
+    }
+}


### PR DESCRIPTION
Add check for duplicity of ingredients, as that is not allowed and exception
must be thrown (on frontend check would be made for this)

Add profile to runners, so they are not being run when testing as they populate
database and that's not needed during testing (each test would populate DB
by themselves, if it would be needed)